### PR TITLE
feat: cache les records d'athlètes pour éviter les appels API répétés

### DIFF
--- a/src/lib/utils/cacheUtils.js
+++ b/src/lib/utils/cacheUtils.js
@@ -1,0 +1,68 @@
+import {browser} from '$app/environment';
+
+const DEFAULT_TTL = 24 * 60 * 60 * 1000; // 24 heures en millisecondes
+
+/**
+ * Récupère une entrée du cache localStorage
+ * @param {string} key - Clé du cache
+ * @return {*|null} - Données cachées ou null si expirées/inexistantes
+ */
+export function getFromCache(key) {
+  if (!browser) return null;
+
+  try {
+    const cached = localStorage.getItem(key);
+    if (!cached) return null;
+
+    const {data, expiresAt} = JSON.parse(cached);
+
+    if (Date.now() > expiresAt) {
+      localStorage.removeItem(key);
+      return null;
+    }
+
+    return data;
+  } catch (error) {
+    console.error('Erreur lecture cache:', error);
+    return null;
+  }
+}
+
+/**
+ * Stocke une entrée dans le cache localStorage avec TTL
+ * @param {string} key - Clé du cache
+ * @param {*} data - Données à cacher
+ * @param {number} ttl - Durée de vie en millisecondes (défaut: 24h)
+ */
+export function setInCache(key, data, ttl = DEFAULT_TTL) {
+  if (!browser) return;
+
+  try {
+    const cacheEntry = {
+      data,
+      cachedAt: Date.now(),
+      expiresAt: Date.now() + ttl,
+    };
+    localStorage.setItem(key, JSON.stringify(cacheEntry));
+  } catch (error) {
+    console.error('Erreur écriture cache:', error);
+  }
+}
+
+/**
+ * Supprime une entrée du cache
+ * @param {string} key - Clé du cache
+ */
+export function removeFromCache(key) {
+  if (!browser) return;
+  localStorage.removeItem(key);
+}
+
+/**
+ * Génère la clé de cache pour les records d'un athlète
+ * @param {string} athleteId - ID de l'athlète (FFA ID)
+ * @return {string} - Clé de cache
+ */
+export function getAthleteRecordsCacheKey(athleteId) {
+  return `athlete_records_${athleteId}`;
+}

--- a/tests/utils/cacheUtils.test.js
+++ b/tests/utils/cacheUtils.test.js
@@ -1,0 +1,141 @@
+import {describe, it, expect, beforeEach, vi} from 'vitest';
+import {getFromCache, setInCache, removeFromCache, getAthleteRecordsCacheKey} from '../../src/lib/utils/cacheUtils.js';
+
+describe('cacheUtils', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    vi.useFakeTimers();
+  });
+
+  describe('getAthleteRecordsCacheKey', () => {
+    it('should generate correct cache key for athlete ID', () => {
+      expect(getAthleteRecordsCacheKey('529223')).toBe('athlete_records_529223');
+    });
+
+    it('should handle different athlete IDs', () => {
+      expect(getAthleteRecordsCacheKey('123456')).toBe('athlete_records_123456');
+      expect(getAthleteRecordsCacheKey('abc')).toBe('athlete_records_abc');
+    });
+  });
+
+  describe('setInCache', () => {
+    it('should store data in localStorage', () => {
+      const data = {records: {5000: 900}};
+      setInCache('test_key', data);
+
+      const stored = JSON.parse(localStorage.getItem('test_key'));
+      expect(stored.data).toEqual(data);
+    });
+
+    it('should store cachedAt timestamp', () => {
+      const now = Date.now();
+      setInCache('test_key', {foo: 'bar'});
+
+      const stored = JSON.parse(localStorage.getItem('test_key'));
+      expect(stored.cachedAt).toBe(now);
+    });
+
+    it('should store expiresAt with default TTL of 24h', () => {
+      const now = Date.now();
+      const expectedExpiry = now + 24 * 60 * 60 * 1000;
+      setInCache('test_key', {foo: 'bar'});
+
+      const stored = JSON.parse(localStorage.getItem('test_key'));
+      expect(stored.expiresAt).toBe(expectedExpiry);
+    });
+
+    it('should store expiresAt with custom TTL', () => {
+      const now = Date.now();
+      const customTTL = 60 * 60 * 1000; // 1 heure
+      setInCache('test_key', {foo: 'bar'}, customTTL);
+
+      const stored = JSON.parse(localStorage.getItem('test_key'));
+      expect(stored.expiresAt).toBe(now + customTTL);
+    });
+  });
+
+  describe('getFromCache', () => {
+    it('should return null for non-existent key', () => {
+      expect(getFromCache('non_existent')).toBeNull();
+    });
+
+    it('should return cached data if not expired', () => {
+      const data = {records: {5000: 900, 10000: 1900}};
+      setInCache('test_key', data);
+
+      expect(getFromCache('test_key')).toEqual(data);
+    });
+
+    it('should return null and remove expired cache', () => {
+      const data = {records: {5000: 900}};
+      setInCache('test_key', data, 1000); // TTL de 1 seconde
+
+      // Avancer le temps de 2 secondes
+      vi.advanceTimersByTime(2000);
+
+      expect(getFromCache('test_key')).toBeNull();
+      expect(localStorage.getItem('test_key')).toBeNull();
+    });
+
+    it('should return data just before expiry', () => {
+      const data = {records: {5000: 900}};
+      setInCache('test_key', data, 10000); // TTL de 10 secondes
+
+      // Avancer le temps de 9 secondes (juste avant expiration)
+      vi.advanceTimersByTime(9000);
+
+      expect(getFromCache('test_key')).toEqual(data);
+    });
+
+    it('should handle invalid JSON in localStorage', () => {
+      localStorage.setItem('test_key', 'invalid json');
+
+      expect(getFromCache('test_key')).toBeNull();
+    });
+  });
+
+  describe('removeFromCache', () => {
+    it('should remove entry from localStorage', () => {
+      setInCache('test_key', {foo: 'bar'});
+      expect(localStorage.getItem('test_key')).not.toBeNull();
+
+      removeFromCache('test_key');
+      expect(localStorage.getItem('test_key')).toBeNull();
+    });
+
+    it('should not throw for non-existent key', () => {
+      expect(() => removeFromCache('non_existent')).not.toThrow();
+    });
+  });
+
+  describe('integration', () => {
+    it('should cache and retrieve athlete records', () => {
+      const athleteId = '529223';
+      const records = {
+        5000: 850,
+        10000: 1750,
+        21097: 3900,
+      };
+
+      const cacheKey = getAthleteRecordsCacheKey(athleteId);
+      setInCache(cacheKey, records);
+
+      const retrieved = getFromCache(cacheKey);
+      expect(retrieved).toEqual(records);
+    });
+
+    it('should expire athlete records after TTL', () => {
+      const athleteId = '529223';
+      const records = {5000: 850};
+      const ttl = 24 * 60 * 60 * 1000; // 24h
+
+      const cacheKey = getAthleteRecordsCacheKey(athleteId);
+      setInCache(cacheKey, records, ttl);
+
+      // Avancer de 25 heures
+      vi.advanceTimersByTime(25 * 60 * 60 * 1000);
+
+      expect(getFromCache(cacheKey)).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Ajoute `cacheUtils.js` avec gestion du cache localStorage et TTL de 24h
- Modifie `fetchAthleteRecords` pour vérifier le cache avant d'appeler l'API
- Modifie `toggleAthleteRecords` pour éviter les appels si les records sont déjà en mémoire

Closes #4

## Fonctionnement

1. **Premier affichage d'un athlète** : appel API → records stockés en cache (24h)
2. **Toggle OFF puis ON** : records récupérés depuis la mémoire (pas d'appel)
3. **Rechargement de page** : records récupérés depuis le cache localStorage (pas d'appel)
4. **Après 24h** : cache expiré → nouvel appel API

## Test plan
- [ ] Ajouter un athlète → vérifier l'appel API dans Network
- [ ] Toggle OFF puis ON → vérifier qu'il n'y a PAS d'appel API
- [ ] Recharger la page avec l'athlète visible → vérifier qu'il n'y a PAS d'appel API
- [ ] Vérifier que les records s'affichent correctement dans tous les cas