### PR TITLE
feat(club-landing): met en valeur les enrichissements DEC-154/155

### DIFF
--- a/src/lib/components/ClubReportMockup.svelte
+++ b/src/lib/components/ClubReportMockup.svelte
@@ -6,7 +6,7 @@
 
   const clubName = 'AC Démo Athlétisme';
   const dateRange = 'du 17/03 au 23/03';
-  const stats = {athletes: 12, highlights: 3, perfsHigh: 4};
+  const stats = {athletes: 12, highlights: 4, perfsHigh: 5};
 
   const highlights = [
     {
@@ -31,6 +31,27 @@
       meta: '978 pts • N3 • 2e',
       qualif: {label: 'QE', bg: '#f3e8ff', color: '#6b21a8'},
     },
+    {
+      medal: '🥇',
+      borderColor: '#f59e0b',
+      bgCard: '#fffbeb',
+      nom: 'GIRARD Patrick',
+      epreuve: '10 km Route',
+      tour: '',
+      perf: '38\'12"',
+      meta: 'R6 • 512e (1er M4)',
+    },
+    {
+      medal: '',
+      borderColor: '#e2e8f0',
+      bgCard: '#ffffff',
+      nom: 'ROUSSEAU Karim',
+      epreuve: 'Marathon',
+      tour: '',
+      perf: '2h41\'18"',
+      meta: '1 187 pts • IR2 • 1 234e',
+      record: true,
+    },
   ];
 
   const results = [
@@ -43,7 +64,7 @@
     },
     {
       group: '23/03 à Saint-Étienne',
-      items: [{nom: 'MOREAU Anaïs', epreuve: '1 500m', perf: '4\'38"15', meta: '821 pts • IR4 • 4e'}],
+      items: [{nom: 'MOREAU Anaïs', epreuve: '1 500m', perf: '4\'38"15', meta: '821 pts • IR4 • 4e (2e F)'}],
     },
   ];
 </script>
@@ -82,13 +103,25 @@
       </tr>
     </table>
 
+    <!-- Légende des badges -->
+    <div class="legend">
+      <span class="record">RP</span> Record personnel
+      <span class="legend-sep" aria-hidden="true">·</span>
+      <span class="qualif legend-qi">QI</span> Qualification individuelle
+      <span class="legend-sep" aria-hidden="true">·</span>
+      <span class="qualif legend-qe">QE</span> Qualification équipe
+    </div>
+
     <!-- Highlights -->
     <div class="highlights">
       <h4 class="highlights-title">🏆 Podiums et hautes performances</h4>
       {#each highlights as h}
         <div class="card" style:border-left-color={h.borderColor} style:background-color={h.bgCard}>
           <div class="card-left">
-            <div class="card-name"><span class="medal">{h.medal}</span> {h.nom}</div>
+            <div class="card-name">
+              {#if h.medal}<span class="medal">{h.medal}</span>
+              {/if}{h.nom}
+            </div>
             <div class="card-event">
               {h.epreuve}{#if h.tour}
                 <span class="tour">- {h.tour}</span>{/if}
@@ -101,6 +134,9 @@
                 <span class="qualif" style:background-color={h.qualif.bg} style:color={h.qualif.color}>
                   {h.qualif.label}
                 </span>
+              {/if}
+              {#if h.record}
+                <span class="record">RP</span>
               {/if}
             </div>
             <div class="card-meta">{h.meta}</div>
@@ -351,9 +387,45 @@
   .qualif {
     padding: 1px 5px;
     border-radius: 3px;
-    font-size: 10px;
+    font-size: 12px;
     font-weight: bold;
     letter-spacing: 0.03em;
+  }
+
+  /* Badge record personnel — violet « record de secteur » F1, fidèle à reporter.py */
+  .record {
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.03em;
+    background-color: #7c3aed;
+    color: #ffffff;
+  }
+
+  .legend {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    flex-wrap: wrap;
+    font-size: 12px;
+    color: #64748b;
+    margin-bottom: 18px;
+  }
+
+  .legend-qi {
+    background-color: #dbeafe;
+    color: #1e40af;
+  }
+
+  .legend-qe {
+    background-color: #f3e8ff;
+    color: #6b21a8;
+  }
+
+  .legend-sep {
+    color: #cbd5e1;
   }
 
   .card-meta {

--- a/src/routes/club/+page.svelte
+++ b/src/routes/club/+page.svelte
@@ -49,6 +49,26 @@
     },
   ];
 
+  const smartFeatures = [
+    {
+      title: 'Podiums scratch et catégories',
+      body: "512e au scratch, mais 1er en M4. Un classement brut l'aurait noyé dans la masse — MyPacer Club repère la médaille de catégorie et la met en avant. Vos masters, vos jeunes, vos féminines : chacun voit sa vraie place.",
+    },
+    {
+      title: 'Détection des records personnels',
+      body: "Quand un athlète bat son record personnel, le rapport le signale d'un badge.",
+      badges: [{label: 'RP', bg: '#7c3aed', color: '#ffffff'}],
+    },
+    {
+      title: 'Qualifications aux championnats (qi/qe)',
+      body: 'Qualifications individuelles et par équipe : détectés en direct depuis la base FFA, sans risque d’oubli.',
+      badges: [
+        {label: 'QI', bg: '#dbeafe', color: '#1e40af'},
+        {label: 'QE', bg: '#f3e8ff', color: '#6b21a8'},
+      ],
+    },
+  ];
+
   const faq = [
     {
       question: "On n'a plus de budget à cette période de l'année.",
@@ -184,6 +204,36 @@
         </div>
       </li>
     </ol>
+  </section>
+
+  <!-- Intelligence du rapport -->
+  <section class="smart-section">
+    <header class="section-header">
+      <p class="eyebrow">Plus qu'un copier-coller</p>
+      <h2>Plus fin qu'un classement au scratch</h2>
+      <p>
+        Le rapport ne se contente pas de recopier la base FFA : il lit entre les lignes pour ne rien laisser passer de
+        ce qui mérite d'être célébré.
+      </p>
+    </header>
+
+    <div class="smart-grid">
+      {#each smartFeatures as feature}
+        <div class="smart-card">
+          <h3>{feature.title}</h3>
+          {#if feature.badges}
+            <div class="smart-badges">
+              {#each feature.badges as badge}
+                <span class="report-badge" style:background-color={badge.bg} style:color={badge.color}>
+                  {badge.label}
+                </span>
+              {/each}
+            </div>
+          {/if}
+          <p>{feature.body}</p>
+        </div>
+      {/each}
+    </div>
   </section>
 
   <!-- Offres -->
@@ -466,6 +516,54 @@
   }
 
   /* -------------------------------------------------------------------------- */
+  /* Intelligence du rapport                                                    */
+  /* -------------------------------------------------------------------------- */
+  .smart-section {
+    padding: var(--spacing-2xl) 0;
+    border-top: var(--border-width) solid var(--color-neutral-200);
+  }
+
+  .smart-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: var(--spacing-lg);
+  }
+
+  .smart-card {
+    padding: var(--spacing-lg);
+    background-color: var(--color-neutral-50);
+    border: var(--border-width) solid var(--color-neutral-200);
+    border-top: 4px solid var(--color-primary-500);
+    border-radius: var(--border-radius-lg);
+  }
+
+  .smart-card h3 {
+    font-size: var(--font-size-lg);
+    margin: 0 0 var(--spacing-sm) 0;
+  }
+
+  .smart-card p {
+    margin: 0;
+    color: var(--color-neutral-700);
+    font-size: var(--font-size-sm);
+  }
+
+  /* Badges reproduisant fidèlement la charte des pilules du rapport (reporter.py) */
+  .smart-badges {
+    display: flex;
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  .report-badge {
+    padding: 1px 5px;
+    border-radius: 3px;
+    font-size: 12px;
+    font-weight: bold;
+    letter-spacing: 0.03em;
+  }
+
+  /* -------------------------------------------------------------------------- */
   /* Section headers                                                            */
   /* -------------------------------------------------------------------------- */
   .section-header {
@@ -696,7 +794,8 @@
     }
 
     .two-col,
-    .offers-grid {
+    .offers-grid,
+    .smart-grid {
       grid-template-columns: 1fr;
       gap: var(--spacing-xl);
     }

--- a/tests/routes/clubMarketingCopy.test.js
+++ b/tests/routes/clubMarketingCopy.test.js
@@ -26,4 +26,14 @@ describe('MyPacer Club marketing copy', () => {
     expect(clubPage).not.toContain('rapport exhaustif');
     expect(clubPage).toContain('Synthèse hebdomadaire à partir des résultats publics FFA');
   });
+
+  it('highlights the smart enrichments with report-charte badges', () => {
+    expect(normalizedClubPage).toContain('Podiums scratch et catégories');
+    expect(normalizedClubPage).toContain('Détection des records personnels');
+    expect(normalizedClubPage).toContain('Qualifications aux championnats (qi/qe)');
+    // Badges des smart cards aux couleurs exactes du rapport (reporter.py) :
+    // RP violet, QE violet clair.
+    expect(clubPage).toContain('#7c3aed');
+    expect(clubPage).toContain('#6b21a8');
+  });
 });


### PR DESCRIPTION
## Résumé
Page de présentation MyPacer Club mise à jour pour valoriser les deux nouveaux enrichissements du rapport :
- **Mockup** : couvre chaque cas distinctement — podium scratch + QI/QE, podium catégorie (1er M4), record perso sans podium — avec la charte exacte du vrai mail (badges 12px).
- **Légende** : RP / QI / QE avec labels complets (Record personnel, Qualification individuelle, Qualification équipe).
- **Section « Plus fin qu'un classement au scratch »** : 3 smart cards avec badges RP/QI/QE aux couleurs du rapport.

## Test Plan
- [x] `prettier --check` + `eslint`
- [x] `vitest` (114 tests, dont `clubMarketingCopy`)
- [x] `vite build`
- [x] Vérification visuelle (légende + smart cards) via Playwright